### PR TITLE
PHPDoc のアノテーションの並び順を設定

### DIFF
--- a/src/Rules.php
+++ b/src/Rules.php
@@ -122,6 +122,7 @@ class Rules
         'phpdoc_no_access' => true,
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_order' => ['order'=>['param', 'return', 'throws']],
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,


### PR DESCRIPTION
アノテーションの並びが修正されるようにしました

例）

```
    /**
     * @return void
     *
     * @param CalenderApiClient $calender_api_client
     * @param SlackService      $slack_service
     * @param CompanyService    $company_service
     *
     */
```
↓
```
    /**
     * @param CalenderApiClient $calender_api_client
     * @param SlackService      $slack_service
     * @param CompanyService    $company_service
     *
     * @return void
     */
```