### PR TITLE
メソッドシグネチャで @param が並び替わるようにした

### DIFF
--- a/src/Rules.php
+++ b/src/Rules.php
@@ -123,6 +123,7 @@ class Rules
         'phpdoc_no_package' => true,
         'phpdoc_no_useless_inheritdoc' => true,
         'phpdoc_order' => ['order'=>['param', 'return', 'throws']],
+        'phpdoc_param_order' => true,
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,


### PR DESCRIPTION
題名のとおりです。
`phpdoc_param_order` を適用しました

↓挙動はこんな感じです
![image](https://github.com/crew-bit/php-cs-fixer-rules/assets/43082614/40be96cb-54da-471c-b5d6-4a3ae72e6504)

参考: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/phpdoc/phpdoc_param_order.rst